### PR TITLE
Fix codestream_info memory leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 JS/WebAssembly build of [OpenJPEG](https://github.com/uclouvain/openjpeg)
 
-NOTE - a forked version of OpenJPEG is currently used which has some changes to allow partial bitstream decoding
-
 ## Try It Out!
 
 Try it in your browser [here](https://chafey.github.io/openjpegjs/test/browser/index.html)

--- a/src/J2KDecoder.hpp
+++ b/src/J2KDecoder.hpp
@@ -219,6 +219,8 @@ class J2KDecoder {
   private:
 
     void decode_i(size_t decompositionLevel) {
+      decoded_.clear();
+      
       opj_dparameters_t parameters;
       opj_codec_t* l_codec = NULL;
       opj_image_t* image = NULL;

--- a/src/J2KDecoder.hpp
+++ b/src/J2KDecoder.hpp
@@ -269,15 +269,6 @@ class J2KDecoder {
           return;
       }
       
-      /* decode the image */
-      if (!opj_decode(l_codec, l_stream, image)) {
-          printf("[ERROR] opj_decompress: failed to decode tile!\n");
-          opj_destroy_codec(l_codec);
-          opj_stream_destroy(l_stream);
-          opj_image_destroy(image);
-          return;
-      }
-
       frameInfo_.width = image->x1; 
       frameInfo_.height = image->y1;
       frameInfo_.componentCount = image->numcomps;
@@ -308,6 +299,15 @@ class J2KDecoder {
       const size_t bytesPerPixel = (frameInfo_.bitsPerSample + 8 - 1) / 8;
       const size_t destinationSize = sizeAtDecompositionLevel.width * sizeAtDecompositionLevel.height * frameInfo_.componentCount * bytesPerPixel;
       decoded_.resize(destinationSize);
+
+      /* decode the image */
+      if (!opj_decode(l_codec, l_stream, image)) {
+          printf("[ERROR] opj_decompress: failed to decode tile!\n");
+          opj_destroy_codec(l_codec);
+          opj_stream_destroy(l_stream);
+          opj_image_destroy(image);
+          return;
+      }
 
       // Convert from int32 to native size
       int comp_num;

--- a/src/J2KDecoder.hpp
+++ b/src/J2KDecoder.hpp
@@ -300,6 +300,7 @@ class J2KDecoder {
       tileSize_.width = cstr_info->tdx;
       tileSize_.height = cstr_info->tdy;
       numDecompositions_ = cstr_info->m_default_tile_info.tccp_info->numresolutions - 1;
+      opj_destroy_cstr_info(&cstr_info);
       
       // calculate the resolution at the requested decomposition level and
       // allocate destination buffer


### PR DESCRIPTION
1. The return value from opj_get_cstr_info has to be freed by calling opj_destroy_cstr_info.
2. It is convenient to allocate the output image buffer (decoded_) before calling opj_decode; this was observed to allow failure sooner if there wasn't enough memory to decode AND return the image.
3. Minor correction to readme - it appears that openjpeg master branch is used now
4. decoded_ buffer is cleared at start of decode_i() to reduce memory footprint (i.e. before openjpeg objects are allocated)